### PR TITLE
Felix UI round logic

### DIFF
--- a/legacy_files/config_5Apr_2025.json
+++ b/legacy_files/config_5Apr_2025.json
@@ -1,6 +1,6 @@
 {
     "logfile" : "app.log",
-    "layouts" : ["cramped_room","asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit"],
+    "layouts" : ["cramped_room","counter_circuit_o_1order", "cramped_room_tomato", "asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit", "cramped_corridor", "marshmallow_experiment", "long_cook_time", "forced_coordination_tomato", "asymmetric_advantages_tomato", "marshmallow_experiment_coordination", "pipeline", "you_shall_not_pass", "tutorial_3"],
     "MAX_GAMES" : 20,
     "MAX_GAME_LENGTH" : 120,
     "AGENT_DIR" : "./static/assets/agents",
@@ -20,8 +20,7 @@
         "tutorialParams" : {
             "layouts" : [ "tutorial_0", "tutorial_0", "tutorial_0", "tutorial_0"],
             "playerZero" : "human",
-            "playerOne" : "TutorialAI",
-            "oldDynamics": "on"
+            "playerOne" : "TutorialAI"
         },
         "tomato_value" : 13,
         "onion_value" : 21
@@ -33,16 +32,5 @@
         "tomato_time" : 7,
         "order_bonus" : 2,
         "max_num_ingredients" : 3
-    },
-    "default_layout": "cramped_room",
-    "layout_agent_mapping": {
-        "cramped_room": "PPOCrampedRoom",
-        "asymmetric_advantages": "PPOAsymmetricAdvantages",
-        "coordination_ring": "PPOCoordinationRing",
-        "forced_coordination": "PPOForcedCoordination",
-        "counter_circuit": "PPOCounterCircuit"
-    },
-    "total_num_rounds": 4,
-    "initial_round": 1,
-    "initial_session": 1
+    }
 }

--- a/legacy_files/graphics_old.js
+++ b/legacy_files/graphics_old.js
@@ -17,7 +17,6 @@ var DIRECTION_TO_NAME = {
     '-1,0': 'WEST'
 };
 
-var ADAX_UI_HEIGHT = 80;
 var scene_config = {
     player_colors : {0: 'blue', 1: 'green'},
     tileSize : 80,
@@ -25,12 +24,8 @@ var scene_config = {
     show_post_cook_time : false,
     cook_time : 20,
     assets_loc : "./static/assets/",
-    hud_size : 150 + ADAX_UI_HEIGHT,
-    adax_explanation: '',
-    current_round: 1,
-    current_session: 1,
-    total_rounds: 1,
-    current_layout: ""
+    hud_size : 200,
+    adax_explanation: ''
 };
 
 var game_config = {
@@ -55,8 +50,8 @@ function drawState(state) {
 
 // Invoked at 'start_game' event
 function graphics_start(graphics_config) {
-    // console.log("===graphics_config", graphics_config)
-    // console.log("===scene_config", scene_config)
+    console.log("===graphics_config", graphics_config)
+    console.log("===scene_config", scene_config)
     graphics = new GraphicsManager(game_config, scene_config, graphics_config);
 };
 
@@ -72,13 +67,9 @@ class GraphicsManager {
         let start_info = graphics_config.start_info;
         scene_config.terrain = start_info.terrain;
         scene_config.start_state = start_info.state;
-        scene_config.isAdaxAgent = start_info.isAdaxAgent;
-        scene_config.currentSession = start_info.currentSession;
-        scene_config.currentRound = start_info.currentRound;
-        scene_config.currentLayout = start_info.currentLayout;
         game_config.scene = new OvercookedScene(scene_config);
         game_config.width = scene_config.tileSize*scene_config.terrain[0].length;
-        game_config.height = scene_config.tileSize*scene_config.terrain.length  + scene_config.hud_size - (start_info.isAdaxAgent ? 0 : ADAX_UI_HEIGHT);
+        game_config.height = scene_config.tileSize*scene_config.terrain.length  + scene_config.hud_size;
         game_config.parent = graphics_config.container_id;
         this.game = new Phaser.Game(game_config);
     }
@@ -99,34 +90,25 @@ class OvercookedScene extends Phaser.Scene {
         this.show_post_cook_time = config.show_post_cook_time;
         this.cook_time = config.cook_time;
         this.assets_loc = config.assets_loc;
-        this.hud_size = config.isAdaxAgent ? config.hud_size : config.hud_size - ADAX_UI_HEIGHT;
-        this.agent_msg_size = config.isAdaxAgent ? 80 : 0
+        this.hud_size = config.hud_size
         this.hud_data = {
             potential : config.start_state.potential,
             score : config.start_state.score,
             time : config.start_state.time_left,
             bonus_orders : config.start_state.state.bonus_orders,
             all_orders : config.start_state.state.all_orders,
-            isAdaxAgent: config.isAdaxAgent,
-            adax_explanation: config.adax_explanation,
-            current_round: config.currentRound,
-            total_rounds: config.totalRounds,
-            current_session: config.currentSession,
-            current_layout: config.currentLayout
+            adax_explanation: config.start_state.adax_explanation
         }
     }
 
     set_state(state) {
+        console.log("state,", state)
         this.hud_data.potential = state.potential;
         this.hud_data.score = state.score;
         this.hud_data.time = Math.round(state.time_left);
         this.hud_data.bonus_orders = state.state.bonus_orders;
         this.hud_data.all_orders = state.state.all_orders;
         this.hud_data.adax_explanation = state.adax_explanation;
-        this.hud_data.current_round = state.current_round;
-        this.hud_data.current_session = state.current_session;
-        this.hud_data.current_layout = state.current_layout;
-        this.hud_data.total_rounds = state.total_rounds;
         this.state = state.state;
     }
 
@@ -183,7 +165,7 @@ class OvercookedScene extends Phaser.Scene {
                 let ttype = pos_dict[row][col];
                 let tile = this.add.sprite(
                     this.tileSize * x,
-                    this.tileSize * y + this.agent_msg_size,
+                    this.tileSize * y,
                     "tiles",
                     terrain_to_img[ttype]
                 );
@@ -194,6 +176,7 @@ class OvercookedScene extends Phaser.Scene {
     }
     _drawState (state, sprites) {
         sprites = typeof(sprites) === 'undefined' ? {} : sprites;
+        console.log("statesssss ", state)
         //draw chefs
         sprites['chefs'] =
             typeof(sprites['chefs']) === 'undefined' ? {} : sprites['chefs'];
@@ -222,7 +205,7 @@ class OvercookedScene extends Phaser.Scene {
             if (typeof(sprites['chefs'][pi]) === 'undefined') {
                 let chefsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "chefs",
                     `${dir}${held_obj}.png`
                 );
@@ -231,7 +214,7 @@ class OvercookedScene extends Phaser.Scene {
                 chefsprite.setOrigin(0);
                 let hatsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "chefs",
                     `${dir}-${this.player_colors[pi]}hat.png`
                 );
@@ -248,7 +231,7 @@ class OvercookedScene extends Phaser.Scene {
                 this.tweens.add({
                     targets: [chefsprite, hatsprite],
                     x: this.tileSize*x,
-                    y: this.tileSize*y + this.agent_msg_size,
+                    y: this.tileSize*y,
                     duration: this.animation_duration,
                     ease: 'Linear',
                     onComplete: (tween, target, player) => {
@@ -291,7 +274,7 @@ class OvercookedScene extends Phaser.Scene {
                 spriteframe = this._ingredientsToSpriteFrame(ingredients, soup_status);
                 let objsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "soups",
                     spriteframe
                 );
@@ -308,7 +291,7 @@ class OvercookedScene extends Phaser.Scene {
                 if (show_time) {
                     let timesprite =  this.add.text(
                         this.tileSize*(x+.5),
-                        this.tileSize*(y+.6) + this.agent_msg_size,
+                        this.tileSize*(y+.6),
                         String(obj._cooking_tick),
                         {
                             font: "25px Arial",
@@ -328,7 +311,7 @@ class OvercookedScene extends Phaser.Scene {
                 spriteframe = this._ingredientsToSpriteFrame(ingredients, soup_status);
                 let objsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "soups",
                     spriteframe
                 );
@@ -349,7 +332,7 @@ class OvercookedScene extends Phaser.Scene {
                 }
                 let objsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "objects",
                     spriteframe
                 );
@@ -362,10 +345,7 @@ class OvercookedScene extends Phaser.Scene {
     }
 
     _drawHUD(hud_data, sprites, board_height) {
-        // console.log("================", sprites);
-        if (hud_data.isAdaxAgent && typeof(hud_data.adax_explanation) !== 'undefined' && hud_data.adax_explanation !== null) {
-            this._drawAdaXplanation(hud_data.adax_explanation, sprites, board_height);
-        }
+        console.log("================", hud_data)
         if (typeof(hud_data.all_orders) !== 'undefined') {
             this._drawAllOrders(hud_data.all_orders, sprites, board_height);
         }
@@ -379,16 +359,12 @@ class OvercookedScene extends Phaser.Scene {
             this._drawScore(hud_data.score, sprites, board_height);
         }
         if (typeof(hud_data.potential) !== 'undefined' && hud_data.potential !== null) {
+            console.log(hud_data.potential)
             this._drawPotential(hud_data.potential, sprites, board_height);
         }
-        if (typeof(hud_data.current_round) !== 'undefined') {
-            this._drawCurrentRound(hud_data.current_round, sprites, board_height);
-        }
-        if (typeof(hud_data.current_session) !== 'undefined') {
-            this._drawCurrentSession(hud_data.current_session, sprites, board_height);
-        }
-        if (typeof(hud_data.current_layout) !== 'undefined') {
-            this._drawCurrentLayout(hud_data.current_layout, sprites, board_height);
+        if (typeof(hud_data.adax_explanation) !== 'undefined' && hud_data.adax_explanation !== null) {
+            console.log(hud_data.adax_explanation)
+            this._drawAdaXplanation(hud_data.adax_explanation, sprites, board_height);
         }
     }
 
@@ -407,7 +383,7 @@ class OvercookedScene extends Phaser.Scene {
                     let spriteFrame = this._ingredientsToSpriteFrame(orders[i]['ingredients'], "done");
                     let orderSprite = this.add.sprite(
                         130 + 40 * i,
-                        board_height + 40 + this.agent_msg_size,
+                        board_height + 40,
                         "soups",
                         spriteFrame
                     );
@@ -420,7 +396,7 @@ class OvercookedScene extends Phaser.Scene {
             else {
                 sprites['bonus_orders'] = {};
                 sprites['bonus_orders']['str'] = this.add.text(
-                    5, board_height + 60 + this.agent_msg_size, orders_str,
+                    5, board_height + 60, orders_str,
                     {
                         font: "20px Arial",
                         fill: "red",
@@ -447,7 +423,7 @@ class OvercookedScene extends Phaser.Scene {
                     let spriteFrame = this._ingredientsToSpriteFrame(orders[i]['ingredients'], "done");
                     let orderSprite = this.add.sprite(
                         90 + 40 * i,
-                        board_height - 4 + this.agent_msg_size,
+                        board_height - 4,
                         "soups",
                         spriteFrame
                     );
@@ -460,7 +436,7 @@ class OvercookedScene extends Phaser.Scene {
             else {
                 sprites['all_orders'] = {};
                 sprites['all_orders']['str'] = this.add.text(
-                    5, board_height + 15 + this.agent_msg_size, orders_str,
+                    5, board_height + 15, orders_str,
                     {
                         font: "20px Arial",
                         fill: "red",
@@ -479,7 +455,7 @@ class OvercookedScene extends Phaser.Scene {
         }
         else {
             sprites['score'] = this.add.text(
-                5, board_height + 90 + this.agent_msg_size, score,
+                5, board_height + 90, score,
                 {
                     font: "20px Arial",
                     fill: "red",
@@ -496,7 +472,7 @@ class OvercookedScene extends Phaser.Scene {
         }
         else {
             sprites['potential'] = this.add.text(
-                100, board_height + 90 + this.agent_msg_size, potential,
+                100, board_height + 90, potential,
                 {
                     font: "20px Arial",
                     fill: "red",
@@ -513,62 +489,11 @@ class OvercookedScene extends Phaser.Scene {
         }
         else {
             sprites['time_left'] = this.add.text(
-                5, board_height + 115 + this.agent_msg_size, time_left,
+                5, board_height + 115, time_left,
                 {
                     font: "20px Arial",
                     fill: "red",
                     align: "left"
-                }
-            )
-        }
-    }
-
-    _drawCurrentRound(current_round, sprites, board_height) {
-        current_round = "Round: "+current_round;
-        if (typeof(sprites['current_round']) !== 'undefined') {
-            sprites['current_round'].setText(current_round);
-        }
-        else {
-            sprites['current_round'] = this.add.text(
-                0.5*this.game.canvas.width, board_height + 60 + this.agent_msg_size, current_round,
-                {
-                    font: "20px Arial",
-                    fill: "red",
-                    align: "right"
-                }
-            )
-        }
-    }
-
-    _drawCurrentSession(current_session, sprites, board_height) {
-        current_session = "Session: "+current_session;
-        if (typeof(sprites['current_session']) !== 'undefined') {
-            sprites['current_session'].setText(current_session);
-        }
-        else {
-            sprites['current_session'] = this.add.text(
-                0.5*this.game.canvas.width, board_height + 90 + this.agent_msg_size, current_session,
-                {
-                    font: "20px Arial",
-                    fill: "red",
-                    align: "right"
-                }
-            )
-        }
-    }
-
-    _drawCurrentLayout(current_layer, sprites, board_height) {
-        current_layer = "Layer: "+current_layer;
-        if (typeof(sprites['current_layer']) !== 'undefined') {
-            sprites['current_layer'].setText(current_layer);
-        }
-        else {
-            sprites['current_layer'] = this.add.text(
-                0.5*this.game.canvas.width, board_height + 115 + this.agent_msg_size, current_layer,
-                {
-                    font: "20px Arial",
-                    fill: "red",
-                    align: "right"
                 }
             )
         }
@@ -581,31 +506,23 @@ class OvercookedScene extends Phaser.Scene {
     }
 
     _drawAdaXplanation(adax_explanation, sprites, board_height) {
-        // adax_explanation = "AI Chef's msg: "+ adax_explanation;
+        adax_explanation = "AI Chef's reason: "+ adax_explanation;
         if (typeof(sprites['adax_explanation']) !== 'undefined') {
             sprites['adax_explanation'].setText(adax_explanation);
         }
         else {
-            sprites['base_adax_label'] = this.add.text(
-                5, 5, "AI Chef's msg: ",
+            sprites['adax_explanation'] = this.add.text(
+                5, board_height + 150, adax_explanation,
                 {
                     font: "20px Arial",
                     fill: "green",
                     align: "left",
-                    // wordWrap: { width: this.game.canvas.width - 10, useAdvancedWrap: true }
-                }
-            )
-            sprites['adax_explanation'] = this.add.text(
-                5, 30, adax_explanation,
-                {
-                    font: "20px Arial",
-                    fill: "black",
-                    align: "left",
-                    wordWrap: { width: this.game.canvas.width - 20, useAdvancedWrap: true }
+                    wordWrap: { width: this.game.canvas.width - 10, useAdvancedWrap: true }
                 }
             )
             
         }
     }
+    
 }
 

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -305,7 +305,6 @@ def _create_game(user_id,
             game.update_explanation('')
             ACTIVE_GAMES.add(game.id)
             start_info = game.to_json()
-            start_info["isAdaxAgent"] = params["adaxAgent"]
             start_info["currentSession"] = current_session
             start_info["currentRound"] = current_round
             start_info["totalRounds"] = CONFIG["total_num_rounds"]

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -270,8 +270,7 @@ def _leave_game(user_id):
 
     return was_active
 
-initial_session = 1
-initial_round = 1
+
 def _create_game(user_id,
                  game_name,
                  params={},

--- a/src/overcooked_demo/server/db.json
+++ b/src/overcooked_demo/server/db.json
@@ -1,7 +1,7 @@
 {
     "host": "localhost",
-    "port": 5433,
+    "port": 5432,
     "dbname": "experiments",
-    "user": "experiments",
-    "password": "experiments"
+    "user": "postgres",
+    "password": "admin@123"
 }

--- a/src/overcooked_demo/server/db.json
+++ b/src/overcooked_demo/server/db.json
@@ -1,7 +1,7 @@
 {
     "host": "localhost",
-    "port": 5432,
+    "port": 5433,
     "dbname": "experiments",
-    "user": "postgres",
-    "password": "admin@123"
+    "user": "experiments",
+    "password": "experiments"
 }

--- a/src/overcooked_demo/server/game.py
+++ b/src/overcooked_demo/server/game.py
@@ -487,7 +487,6 @@ class OvercookedGame(Game):
         # session_id = self.commit_hash 
         # self.start_tracking(session_id)
         #self.uid = None
-        self.adax_explanation = 'test'
         self.current_round = current_round
         self.current_session = current_session
         self.total_rounds = total_rounds
@@ -799,7 +798,6 @@ class OvercookedGame(Game):
         state_dict["time_left"] = max(
             self.max_time - (time() - self.start_time), 0
         )
-        state_dict["adax_explanation"] = self.adax_explanation
         state_dict["current_round"] = self.current_round
         state_dict["current_session"] = self.current_session
         state_dict["current_layout"] = self.curr_layout

--- a/src/overcooked_demo/server/static/js/graphics.js
+++ b/src/overcooked_demo/server/static/js/graphics.js
@@ -559,7 +559,7 @@ class OvercookedScene extends Phaser.Scene {
     }
 
     _drawCurrentLayout(current_layer, sprites, board_height) {
-        current_layer = "Layer: "+current_layer;
+        current_layer = "Layout: "+current_layer;
         if (typeof(sprites['current_layer']) !== 'undefined') {
             sprites['current_layer'].setText(current_layer);
         }

--- a/src/overcooked_demo/server/static/js/graphics.js
+++ b/src/overcooked_demo/server/static/js/graphics.js
@@ -73,7 +73,6 @@ class GraphicsManager {
         let start_info = graphics_config.start_info;
         scene_config.terrain = start_info.terrain;
         scene_config.start_state = start_info.state;
-        scene_config.isAdaxAgent = start_info.isAdaxAgent;
         scene_config.currentSession = start_info.currentSession;
         scene_config.currentRound = start_info.currentRound;
         scene_config.currentLayout = start_info.currentLayout;
@@ -110,8 +109,8 @@ class OvercookedScene extends Phaser.Scene {
             time : config.start_state.time_left,
             bonus_orders : config.start_state.state.bonus_orders,
             all_orders : config.start_state.state.all_orders,
-            isAdaxAgent: config.isAdaxAgent,
-            adax_explanation: config.adax_explanation,
+            xaiAgentType: config.xaiAgentType,
+            xai_explanation: config.xai_explanation,
             current_round: config.currentRound,
             total_rounds: config.totalRounds,
             current_session: config.currentSession,
@@ -125,7 +124,6 @@ class OvercookedScene extends Phaser.Scene {
         this.hud_data.time = Math.round(state.time_left);
         this.hud_data.bonus_orders = state.state.bonus_orders;
         this.hud_data.all_orders = state.state.all_orders;
-        this.hud_data.adax_explanation = state.adax_explanation;
         this.hud_data.current_round = state.current_round;
         this.hud_data.current_session = state.current_session;
         this.hud_data.current_layout = state.current_layout;
@@ -369,9 +367,6 @@ class OvercookedScene extends Phaser.Scene {
         // console.log("================", hud_data)
         if (["StaticX", "AdaX"].includes(hud_data.xaiAgentType) && typeof(hud_data.xai_explanation) !== 'undefined' && hud_data.xai_explanation !== null) {
             this._drawAdaXplanation(hud_data.xai_explanation, sprites, board_height);
-        // console.log("================", sprites);
-        if (hud_data.isAdaxAgent && typeof(hud_data.adax_explanation) !== 'undefined' && hud_data.adax_explanation !== null) {
-            this._drawAdaXplanation(hud_data.adax_explanation, sprites, board_height);
         }
         if (typeof(hud_data.all_orders) !== 'undefined') {
             this._drawAllOrders(hud_data.all_orders, sprites, board_height);

--- a/src/overcooked_demo/server/static/js/graphics.js
+++ b/src/overcooked_demo/server/static/js/graphics.js
@@ -27,7 +27,6 @@ var scene_config = {
     assets_loc : "./static/assets/",
     hud_size : 150 + ADAX_UI_HEIGHT,
     xai_exaplanation: '',
-    adax_explanation: '',
     current_round: 1,
     current_session: 1,
     total_rounds: 1,

--- a/src/overcooked_demo/server/static/js/index.js
+++ b/src/overcooked_demo/server/static/js/index.js
@@ -126,6 +126,7 @@ socket.on('start_game', function(data) {
         start_info : data.start_info
     };
     window.spectating = data.spectating;
+    document.getElementById("experiment-order").innerHTML = "Layour Order: " + data.start_info["experiment_order_disp"];
     $('#error-exit').hide();
     $("#overcooked").empty();
     $('#game-over').hide();
@@ -140,6 +141,8 @@ socket.on('start_game', function(data) {
     $('#leave').show();
     $('#leave').attr("disabled", false)
     $('#game-title').show();
+    $('#experiment-order').show();
+    $('#experiment-order').attr("disabled", false)
     
     if (!window.spectating) {
         enable_key_listener();

--- a/src/overcooked_demo/server/static/templates/index.html
+++ b/src/overcooked_demo/server/static/templates/index.html
@@ -98,6 +98,8 @@
     <div id="waiting", class="text-center" style="display:none">
       Waiting for game to be created. Please be patient...
     </div>
+    <div id="experiment-order", class="text-center" style="display:none">
+    </div>
     <div id="overcooked-container" class="text-center">
         <h4 id="game-title" style="display:none">Game in Progress</h4>
         <h4 id="game-over" style="display:none">Game Over</h4>


### PR DESCRIPTION
Updates:
- Automatically moves to another round after a game ends.
- Incorporate rounds and sessions: there are 4 rounds (number of rounds can be configured in config.json key "total_num_rounds"). And the number of sessions of the number of layouts. Each layouts will be played for "total_num_rounds" time before moving on to a new layout.
- Display current round, session and layout on HUD, as well as the expected layout order.