### PR TITLE
UI wizard flow

### DIFF
--- a/legacy_files/config_5Apr_2025.json
+++ b/legacy_files/config_5Apr_2025.json
@@ -1,6 +1,6 @@
 {
     "logfile" : "app.log",
-    "layouts" : ["cramped_room","asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit"],
+    "layouts" : ["cramped_room","counter_circuit_o_1order", "cramped_room_tomato", "asymmetric_advantages", "coordination_ring", "forced_coordination", "counter_circuit", "cramped_corridor", "marshmallow_experiment", "long_cook_time", "forced_coordination_tomato", "asymmetric_advantages_tomato", "marshmallow_experiment_coordination", "pipeline", "you_shall_not_pass", "tutorial_3"],
     "MAX_GAMES" : 20,
     "MAX_GAME_LENGTH" : 120,
     "AGENT_DIR" : "./static/assets/agents",
@@ -20,8 +20,7 @@
         "tutorialParams" : {
             "layouts" : [ "tutorial_0", "tutorial_0", "tutorial_0", "tutorial_0"],
             "playerZero" : "human",
-            "playerOne" : "TutorialAI",
-            "oldDynamics": "on"
+            "playerOne" : "TutorialAI"
         },
         "tomato_value" : 13,
         "onion_value" : 21
@@ -33,16 +32,5 @@
         "tomato_time" : 7,
         "order_bonus" : 2,
         "max_num_ingredients" : 3
-    },
-    "default_layout": "cramped_room",
-    "layout_agent_mapping": {
-        "cramped_room": "PPOCrampedRoom",
-        "asymmetric_advantages": "PPOAsymmetricAdvantages",
-        "coordination_ring": "PPOCoordinationRing",
-        "forced_coordination": "PPOForcedCoordination",
-        "counter_circuit": "PPOCounterCircuit"
-    },
-    "total_num_rounds": 4,
-    "initial_round": 1,
-    "initial_session": 1
+    }
 }

--- a/legacy_files/graphics_old.js
+++ b/legacy_files/graphics_old.js
@@ -17,7 +17,6 @@ var DIRECTION_TO_NAME = {
     '-1,0': 'WEST'
 };
 
-var ADAX_UI_HEIGHT = 80;
 var scene_config = {
     player_colors : {0: 'blue', 1: 'green'},
     tileSize : 80,
@@ -25,12 +24,8 @@ var scene_config = {
     show_post_cook_time : false,
     cook_time : 20,
     assets_loc : "./static/assets/",
-    hud_size : 150 + ADAX_UI_HEIGHT,
-    adax_explanation: '',
-    current_round: 1,
-    current_session: 1,
-    total_rounds: 1,
-    current_layout: ""
+    hud_size : 200,
+    adax_explanation: ''
 };
 
 var game_config = {
@@ -55,8 +50,8 @@ function drawState(state) {
 
 // Invoked at 'start_game' event
 function graphics_start(graphics_config) {
-    // console.log("===graphics_config", graphics_config)
-    // console.log("===scene_config", scene_config)
+    console.log("===graphics_config", graphics_config)
+    console.log("===scene_config", scene_config)
     graphics = new GraphicsManager(game_config, scene_config, graphics_config);
 };
 
@@ -72,13 +67,9 @@ class GraphicsManager {
         let start_info = graphics_config.start_info;
         scene_config.terrain = start_info.terrain;
         scene_config.start_state = start_info.state;
-        scene_config.isAdaxAgent = start_info.isAdaxAgent;
-        scene_config.currentSession = start_info.currentSession;
-        scene_config.currentRound = start_info.currentRound;
-        scene_config.currentLayout = start_info.currentLayout;
         game_config.scene = new OvercookedScene(scene_config);
         game_config.width = scene_config.tileSize*scene_config.terrain[0].length;
-        game_config.height = scene_config.tileSize*scene_config.terrain.length  + scene_config.hud_size - (start_info.isAdaxAgent ? 0 : ADAX_UI_HEIGHT);
+        game_config.height = scene_config.tileSize*scene_config.terrain.length  + scene_config.hud_size;
         game_config.parent = graphics_config.container_id;
         this.game = new Phaser.Game(game_config);
     }
@@ -99,34 +90,25 @@ class OvercookedScene extends Phaser.Scene {
         this.show_post_cook_time = config.show_post_cook_time;
         this.cook_time = config.cook_time;
         this.assets_loc = config.assets_loc;
-        this.hud_size = config.isAdaxAgent ? config.hud_size : config.hud_size - ADAX_UI_HEIGHT;
-        this.agent_msg_size = config.isAdaxAgent ? 80 : 0
+        this.hud_size = config.hud_size
         this.hud_data = {
             potential : config.start_state.potential,
             score : config.start_state.score,
             time : config.start_state.time_left,
             bonus_orders : config.start_state.state.bonus_orders,
             all_orders : config.start_state.state.all_orders,
-            isAdaxAgent: config.isAdaxAgent,
-            adax_explanation: config.adax_explanation,
-            current_round: config.currentRound,
-            total_rounds: config.totalRounds,
-            current_session: config.currentSession,
-            current_layout: config.currentLayout
+            adax_explanation: config.start_state.adax_explanation
         }
     }
 
     set_state(state) {
+        console.log("state,", state)
         this.hud_data.potential = state.potential;
         this.hud_data.score = state.score;
         this.hud_data.time = Math.round(state.time_left);
         this.hud_data.bonus_orders = state.state.bonus_orders;
         this.hud_data.all_orders = state.state.all_orders;
         this.hud_data.adax_explanation = state.adax_explanation;
-        this.hud_data.current_round = state.current_round;
-        this.hud_data.current_session = state.current_session;
-        this.hud_data.current_layout = state.current_layout;
-        this.hud_data.total_rounds = state.total_rounds;
         this.state = state.state;
     }
 
@@ -183,7 +165,7 @@ class OvercookedScene extends Phaser.Scene {
                 let ttype = pos_dict[row][col];
                 let tile = this.add.sprite(
                     this.tileSize * x,
-                    this.tileSize * y + this.agent_msg_size,
+                    this.tileSize * y,
                     "tiles",
                     terrain_to_img[ttype]
                 );
@@ -194,6 +176,7 @@ class OvercookedScene extends Phaser.Scene {
     }
     _drawState (state, sprites) {
         sprites = typeof(sprites) === 'undefined' ? {} : sprites;
+        console.log("statesssss ", state)
         //draw chefs
         sprites['chefs'] =
             typeof(sprites['chefs']) === 'undefined' ? {} : sprites['chefs'];
@@ -222,7 +205,7 @@ class OvercookedScene extends Phaser.Scene {
             if (typeof(sprites['chefs'][pi]) === 'undefined') {
                 let chefsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "chefs",
                     `${dir}${held_obj}.png`
                 );
@@ -231,7 +214,7 @@ class OvercookedScene extends Phaser.Scene {
                 chefsprite.setOrigin(0);
                 let hatsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "chefs",
                     `${dir}-${this.player_colors[pi]}hat.png`
                 );
@@ -248,7 +231,7 @@ class OvercookedScene extends Phaser.Scene {
                 this.tweens.add({
                     targets: [chefsprite, hatsprite],
                     x: this.tileSize*x,
-                    y: this.tileSize*y + this.agent_msg_size,
+                    y: this.tileSize*y,
                     duration: this.animation_duration,
                     ease: 'Linear',
                     onComplete: (tween, target, player) => {
@@ -291,7 +274,7 @@ class OvercookedScene extends Phaser.Scene {
                 spriteframe = this._ingredientsToSpriteFrame(ingredients, soup_status);
                 let objsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "soups",
                     spriteframe
                 );
@@ -308,7 +291,7 @@ class OvercookedScene extends Phaser.Scene {
                 if (show_time) {
                     let timesprite =  this.add.text(
                         this.tileSize*(x+.5),
-                        this.tileSize*(y+.6) + this.agent_msg_size,
+                        this.tileSize*(y+.6),
                         String(obj._cooking_tick),
                         {
                             font: "25px Arial",
@@ -328,7 +311,7 @@ class OvercookedScene extends Phaser.Scene {
                 spriteframe = this._ingredientsToSpriteFrame(ingredients, soup_status);
                 let objsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "soups",
                     spriteframe
                 );
@@ -349,7 +332,7 @@ class OvercookedScene extends Phaser.Scene {
                 }
                 let objsprite = this.add.sprite(
                     this.tileSize*x,
-                    this.tileSize*y + this.agent_msg_size,
+                    this.tileSize*y,
                     "objects",
                     spriteframe
                 );
@@ -362,10 +345,7 @@ class OvercookedScene extends Phaser.Scene {
     }
 
     _drawHUD(hud_data, sprites, board_height) {
-        // console.log("================", sprites);
-        if (hud_data.isAdaxAgent && typeof(hud_data.adax_explanation) !== 'undefined' && hud_data.adax_explanation !== null) {
-            this._drawAdaXplanation(hud_data.adax_explanation, sprites, board_height);
-        }
+        console.log("================", hud_data)
         if (typeof(hud_data.all_orders) !== 'undefined') {
             this._drawAllOrders(hud_data.all_orders, sprites, board_height);
         }
@@ -379,16 +359,12 @@ class OvercookedScene extends Phaser.Scene {
             this._drawScore(hud_data.score, sprites, board_height);
         }
         if (typeof(hud_data.potential) !== 'undefined' && hud_data.potential !== null) {
+            console.log(hud_data.potential)
             this._drawPotential(hud_data.potential, sprites, board_height);
         }
-        if (typeof(hud_data.current_round) !== 'undefined') {
-            this._drawCurrentRound(hud_data.current_round, sprites, board_height);
-        }
-        if (typeof(hud_data.current_session) !== 'undefined') {
-            this._drawCurrentSession(hud_data.current_session, sprites, board_height);
-        }
-        if (typeof(hud_data.current_layout) !== 'undefined') {
-            this._drawCurrentLayout(hud_data.current_layout, sprites, board_height);
+        if (typeof(hud_data.adax_explanation) !== 'undefined' && hud_data.adax_explanation !== null) {
+            console.log(hud_data.adax_explanation)
+            this._drawAdaXplanation(hud_data.adax_explanation, sprites, board_height);
         }
     }
 
@@ -407,7 +383,7 @@ class OvercookedScene extends Phaser.Scene {
                     let spriteFrame = this._ingredientsToSpriteFrame(orders[i]['ingredients'], "done");
                     let orderSprite = this.add.sprite(
                         130 + 40 * i,
-                        board_height + 40 + this.agent_msg_size,
+                        board_height + 40,
                         "soups",
                         spriteFrame
                     );
@@ -420,7 +396,7 @@ class OvercookedScene extends Phaser.Scene {
             else {
                 sprites['bonus_orders'] = {};
                 sprites['bonus_orders']['str'] = this.add.text(
-                    5, board_height + 60 + this.agent_msg_size, orders_str,
+                    5, board_height + 60, orders_str,
                     {
                         font: "20px Arial",
                         fill: "red",
@@ -447,7 +423,7 @@ class OvercookedScene extends Phaser.Scene {
                     let spriteFrame = this._ingredientsToSpriteFrame(orders[i]['ingredients'], "done");
                     let orderSprite = this.add.sprite(
                         90 + 40 * i,
-                        board_height - 4 + this.agent_msg_size,
+                        board_height - 4,
                         "soups",
                         spriteFrame
                     );
@@ -460,7 +436,7 @@ class OvercookedScene extends Phaser.Scene {
             else {
                 sprites['all_orders'] = {};
                 sprites['all_orders']['str'] = this.add.text(
-                    5, board_height + 15 + this.agent_msg_size, orders_str,
+                    5, board_height + 15, orders_str,
                     {
                         font: "20px Arial",
                         fill: "red",
@@ -479,7 +455,7 @@ class OvercookedScene extends Phaser.Scene {
         }
         else {
             sprites['score'] = this.add.text(
-                5, board_height + 90 + this.agent_msg_size, score,
+                5, board_height + 90, score,
                 {
                     font: "20px Arial",
                     fill: "red",
@@ -496,7 +472,7 @@ class OvercookedScene extends Phaser.Scene {
         }
         else {
             sprites['potential'] = this.add.text(
-                100, board_height + 90 + this.agent_msg_size, potential,
+                100, board_height + 90, potential,
                 {
                     font: "20px Arial",
                     fill: "red",
@@ -513,62 +489,11 @@ class OvercookedScene extends Phaser.Scene {
         }
         else {
             sprites['time_left'] = this.add.text(
-                5, board_height + 115 + this.agent_msg_size, time_left,
+                5, board_height + 115, time_left,
                 {
                     font: "20px Arial",
                     fill: "red",
                     align: "left"
-                }
-            )
-        }
-    }
-
-    _drawCurrentRound(current_round, sprites, board_height) {
-        current_round = "Round: "+current_round;
-        if (typeof(sprites['current_round']) !== 'undefined') {
-            sprites['current_round'].setText(current_round);
-        }
-        else {
-            sprites['current_round'] = this.add.text(
-                0.5*this.game.canvas.width, board_height + 60 + this.agent_msg_size, current_round,
-                {
-                    font: "20px Arial",
-                    fill: "red",
-                    align: "right"
-                }
-            )
-        }
-    }
-
-    _drawCurrentSession(current_session, sprites, board_height) {
-        current_session = "Session: "+current_session;
-        if (typeof(sprites['current_session']) !== 'undefined') {
-            sprites['current_session'].setText(current_session);
-        }
-        else {
-            sprites['current_session'] = this.add.text(
-                0.5*this.game.canvas.width, board_height + 90 + this.agent_msg_size, current_session,
-                {
-                    font: "20px Arial",
-                    fill: "red",
-                    align: "right"
-                }
-            )
-        }
-    }
-
-    _drawCurrentLayout(current_layer, sprites, board_height) {
-        current_layer = "Layer: "+current_layer;
-        if (typeof(sprites['current_layer']) !== 'undefined') {
-            sprites['current_layer'].setText(current_layer);
-        }
-        else {
-            sprites['current_layer'] = this.add.text(
-                0.5*this.game.canvas.width, board_height + 115 + this.agent_msg_size, current_layer,
-                {
-                    font: "20px Arial",
-                    fill: "red",
-                    align: "right"
                 }
             )
         }
@@ -581,31 +506,23 @@ class OvercookedScene extends Phaser.Scene {
     }
 
     _drawAdaXplanation(adax_explanation, sprites, board_height) {
-        // adax_explanation = "AI Chef's msg: "+ adax_explanation;
+        adax_explanation = "AI Chef's reason: "+ adax_explanation;
         if (typeof(sprites['adax_explanation']) !== 'undefined') {
             sprites['adax_explanation'].setText(adax_explanation);
         }
         else {
-            sprites['base_adax_label'] = this.add.text(
-                5, 5, "AI Chef's msg: ",
+            sprites['adax_explanation'] = this.add.text(
+                5, board_height + 150, adax_explanation,
                 {
                     font: "20px Arial",
                     fill: "green",
                     align: "left",
-                    // wordWrap: { width: this.game.canvas.width - 10, useAdvancedWrap: true }
-                }
-            )
-            sprites['adax_explanation'] = this.add.text(
-                5, 30, adax_explanation,
-                {
-                    font: "20px Arial",
-                    fill: "black",
-                    align: "left",
-                    wordWrap: { width: this.game.canvas.width - 20, useAdvancedWrap: true }
+                    wordWrap: { width: this.game.canvas.width - 10, useAdvancedWrap: true }
                 }
             )
             
         }
     }
+    
 }
 

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -305,7 +305,6 @@ def _create_game(user_id,
             game.update_explanation('')
             ACTIVE_GAMES.add(game.id)
             start_info = game.to_json()
-            start_info["isAdaxAgent"] = params["adaxAgent"]
             start_info["currentSession"] = current_session
             start_info["currentRound"] = current_round
             start_info["totalRounds"] = CONFIG["total_num_rounds"]

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -413,7 +413,11 @@ def index():
     else:
         # Handle the case when GET request is received (initial page load)
         uid = session.get('user_id')  # If the UID is already stored in the session
-    default_layout = CONFIG["default_layout"]
+    
+    # Randomize default layout loading
+    default_layouts = CONFIG["layouts"].copy()
+    random.shuffle(default_layouts)
+    default_layout = default_layouts[0] if CONFIG["randomize_layout"] else CONFIG["default_layout"]
     return render_template(
         "index.html",
         agent_names=agent_names, 
@@ -607,10 +611,8 @@ def process_game_flow():
             # Resetting to initial round 1 with new session and new layout
             GAME_FLOW['current_round'] = 1
             GAME_FLOW['current_session'] = current_session + 1
-        # if current_session == len(GAME_FLOW['all_layouts'])-1:
-            # Game flow for the curent user is about to end
-    if current_session >= len(GAME_FLOW['all_layouts']):
-            GAME_FLOW['is_ending'] = 1
+    if GAME_FLOW['current_session'] >= len(GAME_FLOW['all_layouts']) and GAME_FLOW['current_round'] >= GAME_FLOW['total_num_rounds']:
+        GAME_FLOW['is_ending'] = 1
     
 @socketio.on("create")
 def on_create(data):

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -121,7 +121,7 @@ app.secret_key = 'abc'
 
 global xai_agent_type
 xai_agent_type = 'NoX'
-
+user_id = ''
 #################################
 # Global Coordination Functions #
 #################################
@@ -395,6 +395,8 @@ def get_agent_names():
 def index():
     agent_names = get_agent_names()
     # Check if the form was submitted (POST request)
+
+    print("request.method ", request.method)
     if request.method == "POST":
         # Get the UID from the form
         uid = request.form.get('uid')
@@ -402,7 +404,7 @@ def index():
 
         # Store the UID in the session (Flask's session management)
         session['user_id'] = uid
-
+        print("session['user_id'] ", session['user_id'])
         # Optionally, store the UID in the GameSession class
         OvercookedGame.set_uid(uid)
     else:
@@ -553,10 +555,16 @@ def creation_params(params):
 
 @socketio.on("create")
 def on_create(data):
-    user_id = request.sid
+    global user_id
+    print(user_id)
+
+    user_id = request.sid or user_id
+    print(user_id)
+
     with USERS[user_id]:
         # Retrieve current game if one exists
         curr_game = get_curr_game(user_id)
+        print("curr_game ", curr_game)
         if curr_game:
             # Cannot create if currently in a game
             return
@@ -679,7 +687,7 @@ def on_connect():
     USERS[user_id] = Lock()
 
 # TODO: remove adax UI element if adax is unchecked
-@socketio.on("adax")
+@socketio.on("xai_message")
 def on_adax(data):
     user_id = request.sid
     adaxplanation = data["explanation"]
@@ -779,7 +787,7 @@ def play_game(game: OvercookedGame, fps=6):
 if __name__ == "__main__":
     # Dynamically parse host and port from environment variables (set by docker build)
     host = os.getenv("HOST", "0.0.0.0")
-    port = int(os.getenv("PORT", 80))
+    port = int(os.getenv("PORT", 5000))
     print("socket ", host, port)
     # Attach exit handler to ensure graceful shutdown
     atexit.register(on_exit)

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -270,8 +270,7 @@ def _leave_game(user_id):
 
     return was_active
 
-initial_session = 1
-initial_round = 1
+
 def _create_game(user_id,
                  game_name,
                  params={},

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -313,6 +313,7 @@ def _create_game(user_id,
             start_info["totalRounds"] = CONFIG["total_num_rounds"]
             start_info["experiment_order_disp"] = " -> ".join(layouts_order)
             start_info["xaiAgentType"] = params.get("xaiAgentType", xai_agent_type)
+            start_info["current_layout"] = game.curr_layout
 
             emit(
                 "start_game",

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -279,6 +279,7 @@ def _create_game(user_id,
                  **kwargs):
     current_session=kwargs.get("current_session",1)
     current_round=kwargs.get("current_round",1)
+    layouts=kwargs.get("layouts",[]) or params.get("layouts", [])
     layouts_order=kwargs.get("layouts_order",[])
     game_flow_on = kwargs.get('game_flow_on', 0)
     is_ending = kwargs.get('is_ending', 0)
@@ -286,7 +287,7 @@ def _create_game(user_id,
         "current_session": current_session,
         "current_round": current_round,
         "total_rounds": CONFIG["total_num_rounds"],
-        "layouts": [layouts_order[current_session-1]]
+        "layouts": layouts
     })
     game, err = try_create_game(game_name, **params)
     if not game:
@@ -591,6 +592,7 @@ def on_create_next(data):
                         params=params,
                         current_round=GAME_FLOW["current_round"],
                         current_session=GAME_FLOW["current_session"],
+                        layouts=[layouts[GAME_FLOW["current_session"]-1]],
                         layouts_order=GAME_FLOW['all_layouts'],
                         game_flow_on=1,
                         is_ending=GAME_FLOW["is_ending"])
@@ -649,6 +651,7 @@ def on_create(data):
                     params=params,
                     current_session=CONFIG["initial_session"],
                     current_round=CONFIG["initial_round"],
+                    layouts=[layouts[CONFIG["initial_session"]-1]],
                     layouts_order=layouts, 
                     game_flow_on=CONFIG['game_flow_on'])
 

--- a/src/overcooked_demo/server/app.py
+++ b/src/overcooked_demo/server/app.py
@@ -277,9 +277,8 @@ def _create_game(user_id,
                  game_name,
                  params={},
                  **kwargs):
-    current_session=kwargs.get("initial_session",1)
-    current_round=kwargs.get("initial_round",1)
-    layouts=kwargs.get("layouts",[]) or params.get("layouts", [])
+    current_session=kwargs.get("current_session",1)
+    current_round=kwargs.get("current_round",1)
     layouts_order=kwargs.get("layouts_order",[])
     game_flow_on = kwargs.get('game_flow_on', 0)
     is_ending = kwargs.get('is_ending', 0)
@@ -287,7 +286,7 @@ def _create_game(user_id,
         "current_session": current_session,
         "current_round": current_round,
         "total_rounds": CONFIG["total_num_rounds"],
-        "layouts": layouts
+        "layouts": [layouts_order[current_session-1]]
     })
     game, err = try_create_game(game_name, **params)
     if not game:
@@ -590,9 +589,8 @@ def on_create_next(data):
             _create_game(user_id=user_id,
                         game_name=game_name,
                         params=params,
-                        initial_session=GAME_FLOW["current_session"],
-                        initial_round=GAME_FLOW["current_round"],
-                        layouts=[layouts[GAME_FLOW["current_session"]-1]],
+                        current_round=GAME_FLOW["current_round"],
+                        current_session=GAME_FLOW["current_session"],
                         layouts_order=GAME_FLOW['all_layouts'],
                         game_flow_on=1,
                         is_ending=GAME_FLOW["is_ending"])
@@ -649,9 +647,8 @@ def on_create(data):
         _create_game(user_id=user_id,
                     game_name=game_name,
                     params=params,
-                    initial_session=CONFIG["initial_session"],
-                    initial_round=CONFIG["initial_round"],
-                    layouts=[layouts[CONFIG["initial_session"]-1]],
+                    current_session=CONFIG["initial_session"],
+                    current_round=CONFIG["initial_round"],
                     layouts_order=layouts, 
                     game_flow_on=CONFIG['game_flow_on'])
 

--- a/src/overcooked_demo/server/config.json
+++ b/src/overcooked_demo/server/config.json
@@ -44,5 +44,7 @@
     },
     "total_num_rounds": 4,
     "initial_round": 1,
-    "initial_session": 1
+    "initial_session": 1,
+    "game_flow_on": 1,
+    "is_ending": 0
 }

--- a/src/overcooked_demo/server/config.json
+++ b/src/overcooked_demo/server/config.json
@@ -46,5 +46,6 @@
     "initial_round": 1,
     "initial_session": 1,
     "game_flow_on": 1,
-    "is_ending": 0
+    "is_ending": 0,
+    "randomize_layout": true
 }

--- a/src/overcooked_demo/server/db.json
+++ b/src/overcooked_demo/server/db.json
@@ -1,7 +1,7 @@
 {
     "host": "localhost",
-    "port": 5433,
+    "port": 5432,
     "dbname": "experiments",
-    "user": "experiments",
-    "password": "experiments"
+    "user": "postgres",
+    "password": "admin@123"
 }

--- a/src/overcooked_demo/server/db.json
+++ b/src/overcooked_demo/server/db.json
@@ -1,7 +1,7 @@
 {
     "host": "localhost",
-    "port": 5432,
+    "port": 5433,
     "dbname": "experiments",
-    "user": "postgres",
-    "password": "admin@123"
+    "user": "experiments",
+    "password": "experiments"
 }

--- a/src/overcooked_demo/server/db.json
+++ b/src/overcooked_demo/server/db.json
@@ -1,5 +1,5 @@
 {
-    "host": "localhost",
+    "host": "192.168.1.100",
     "port": 5432,
     "dbname": "experiments",
     "user": "postgres",

--- a/src/overcooked_demo/server/game.py
+++ b/src/overcooked_demo/server/game.py
@@ -228,6 +228,7 @@ class Game(ABC):
             return self.Status.RESET
 
         self.apply_actions()
+        print("\nself.is_finished() ",self.is_finished())
         return self.Status.DONE if self.is_finished() else self.Status.ACTIVE
 
     def enqueue_action(self, player_id, action):
@@ -540,9 +541,13 @@ class OvercookedGame(Game):
         return cls.uid_value
         
     def _curr_game_over(self):
+        print("time left ", time() - self.start_time)
+        print("max time ", self.max_time)
         return time() - self.start_time >= self.max_time
     
     def needs_reset(self):
+        print("-->self._curr_game_over() ", self._curr_game_over())
+        print("===> self.is_finished() ", self.is_finished())
         return self._curr_game_over() and not self.is_finished()
 
     def add_player(self, player_id, idx=None, buff_size=-1, is_human=True):
@@ -576,7 +581,9 @@ class OvercookedGame(Game):
         return self.num_players >= self.max_players
 
     def is_finished(self):
-        val = not self.layouts and self._curr_game_over()
+        print("self.layouts ", self.layouts)
+        print("====> self._curr_game_over() ",  self._curr_game_over())
+        val = self._curr_game_over()
         return val
 
     def is_empty(self):
@@ -715,13 +722,14 @@ class OvercookedGame(Game):
         print("Resetting, moving to new round...")
         if self.current_round < self.total_rounds:
             self.set_round(self.current_round + 1)
+            self.set_layout(self.layouts[self.current_session])
         else:
             print("Moving to new session...")
             if self.current_session < len(self.layouts):
                 # Resetting to initial round 1 with new session and new layout
                 self.set_round(CONFIG["initial_round"])
-                self.set_session(self.current_session + 1)
                 self.set_layout(self.layouts[self.current_session])
+                self.set_session(self.current_session + 1)
             else:
                 print("End game")
                 if status == self.Status.RESET:
@@ -729,6 +737,30 @@ class OvercookedGame(Game):
                     self.start_time += self.reset_timeout / 1000
 
         print(f"Current round {self.current_round} | session: {self.current_session} | layout: {self.curr_layout} | all layouts: {self.layouts}")\
+
+
+    # def reset(self):
+    #     status = super(OvercookedGame, self).reset()
+    #     print("Resetting, moving to new round...")
+    #     print("self.current_round ",self.current_round)
+    #     print("self.layouts ",self.layouts)
+    #     print("self.current_session ",self.current_session)
+    #     if self.current_round < self.total_rounds:
+    #         self.set_round(self.current_round + 1)
+    #         self.set_layout(self.layouts[self.current_session])
+    #     elif self.current_session < len(self.layouts):
+    #         print("Moving to new session...")
+    #     # if self.current_session < len(self.layouts):
+    #         # Resetting to initial round 1 with new session and new layout
+    #         self.set_round(CONFIG["initial_round"])
+    #         self.set_layout(self.layouts[self.current_session])
+    #         self.set_session(self.current_session + 1)
+    #     print("End game")
+    #     if status == self.Status.RESET:
+    #             # Hacky way of making sure game timer doesn't "start" until after reset timeout has passed
+    #             self.start_time += self.reset_timeout / 1000
+
+    #     print(f"Current round {self.current_round} | session: {self.current_session} | layout: {self.curr_layout} | all layouts: {self.layouts}")\
 
 
     def tick(self):

--- a/src/overcooked_demo/server/game.py
+++ b/src/overcooked_demo/server/game.py
@@ -487,7 +487,6 @@ class OvercookedGame(Game):
         # session_id = self.commit_hash 
         # self.start_tracking(session_id)
         #self.uid = None
-        self.adax_explanation = 'test'
         self.current_round = current_round
         self.current_session = current_session
         self.total_rounds = total_rounds
@@ -799,7 +798,6 @@ class OvercookedGame(Game):
         state_dict["time_left"] = max(
             self.max_time - (time() - self.start_time), 0
         )
-        state_dict["adax_explanation"] = self.adax_explanation
         state_dict["current_round"] = self.current_round
         state_dict["current_session"] = self.current_session
         state_dict["current_layout"] = self.curr_layout

--- a/src/overcooked_demo/server/static/js/graphics.js
+++ b/src/overcooked_demo/server/static/js/graphics.js
@@ -559,7 +559,7 @@ class OvercookedScene extends Phaser.Scene {
     }
 
     _drawCurrentLayout(current_layer, sprites, board_height) {
-        current_layer = "Layer: "+current_layer;
+        current_layer = "Layout: "+current_layer;
         if (typeof(sprites['current_layer']) !== 'undefined') {
             sprites['current_layer'].setText(current_layer);
         }

--- a/src/overcooked_demo/server/static/js/graphics.js
+++ b/src/overcooked_demo/server/static/js/graphics.js
@@ -73,7 +73,6 @@ class GraphicsManager {
         let start_info = graphics_config.start_info;
         scene_config.terrain = start_info.terrain;
         scene_config.start_state = start_info.state;
-        scene_config.isAdaxAgent = start_info.isAdaxAgent;
         scene_config.currentSession = start_info.currentSession;
         scene_config.currentRound = start_info.currentRound;
         scene_config.currentLayout = start_info.currentLayout;
@@ -110,8 +109,8 @@ class OvercookedScene extends Phaser.Scene {
             time : config.start_state.time_left,
             bonus_orders : config.start_state.state.bonus_orders,
             all_orders : config.start_state.state.all_orders,
-            isAdaxAgent: config.isAdaxAgent,
-            adax_explanation: config.adax_explanation,
+            xaiAgentType: config.xaiAgentType,
+            xai_explanation: config.xai_explanation,
             current_round: config.currentRound,
             total_rounds: config.totalRounds,
             current_session: config.currentSession,
@@ -125,7 +124,6 @@ class OvercookedScene extends Phaser.Scene {
         this.hud_data.time = Math.round(state.time_left);
         this.hud_data.bonus_orders = state.state.bonus_orders;
         this.hud_data.all_orders = state.state.all_orders;
-        this.hud_data.adax_explanation = state.adax_explanation;
         this.hud_data.current_round = state.current_round;
         this.hud_data.current_session = state.current_session;
         this.hud_data.current_layout = state.current_layout;
@@ -369,9 +367,6 @@ class OvercookedScene extends Phaser.Scene {
         // console.log("================", hud_data)
         if (["StaticX", "AdaX"].includes(hud_data.xaiAgentType) && typeof(hud_data.xai_explanation) !== 'undefined' && hud_data.xai_explanation !== null) {
             this._drawAdaXplanation(hud_data.xai_explanation, sprites, board_height);
-        // console.log("================", sprites);
-        if (hud_data.isAdaxAgent && typeof(hud_data.adax_explanation) !== 'undefined' && hud_data.adax_explanation !== null) {
-            this._drawAdaXplanation(hud_data.adax_explanation, sprites, board_height);
         }
         if (typeof(hud_data.all_orders) !== 'undefined') {
             this._drawAllOrders(hud_data.all_orders, sprites, board_height);

--- a/src/overcooked_demo/server/static/js/graphics.js
+++ b/src/overcooked_demo/server/static/js/graphics.js
@@ -388,9 +388,9 @@ class OvercookedScene extends Phaser.Scene {
         if (typeof(hud_data.current_session) !== 'undefined') {
             this._drawCurrentSession(hud_data.current_session, sprites, board_height);
         }
-        if (typeof(hud_data.current_layout) !== 'undefined') {
-            this._drawCurrentLayout(hud_data.current_layout, sprites, board_height);
-        }
+        // if (typeof(hud_data.current_layout) !== 'undefined') {
+        //     this._drawCurrentLayout(hud_data.current_layout, sprites, board_height);
+        // }
     }
 
     _drawBonusOrders(orders, sprites, board_height) {

--- a/src/overcooked_demo/server/static/js/graphics.js
+++ b/src/overcooked_demo/server/static/js/graphics.js
@@ -27,7 +27,6 @@ var scene_config = {
     assets_loc : "./static/assets/",
     hud_size : 150 + ADAX_UI_HEIGHT,
     xai_exaplanation: '',
-    adax_explanation: '',
     current_round: 1,
     current_session: 1,
     total_rounds: 1,

--- a/src/overcooked_demo/server/static/js/index.js
+++ b/src/overcooked_demo/server/static/js/index.js
@@ -77,6 +77,8 @@ $(function() {
         try {
             document.getElementById("playerOne").value = agentMapping[layout];
             // document.getElementById("playerOne").text = agentMapping[layout];
+            $('#current-layout').html(layout)
+
         }
         catch(err) {document.getElementById("playerOne").value = window.config_data["layout_agent_mapping"][window.config_data["default_layout"]];console.log(err);}
     });
@@ -152,7 +154,8 @@ socket.on('start_game', function(data) {
         start_info : data.start_info
     };
     window.spectating = data.spectating;
-    document.getElementById("experiment-order").innerHTML = "Layour Order: " + data.start_info["experiment_order_disp"];
+    document.getElementById("experiment-order").innerHTML = "<b>Layout Order:</b> " + data.start_info["experiment_order_disp"];
+    $('#current-layout').html(data.start_info["current_layout"])
     $('#error-exit').hide();
     $("#overcooked").empty();
     $('#game-over').hide();

--- a/src/overcooked_demo/server/static/js/index.js
+++ b/src/overcooked_demo/server/static/js/index.js
@@ -126,6 +126,7 @@ socket.on('start_game', function(data) {
         start_info : data.start_info
     };
     window.spectating = data.spectating;
+    document.getElementById("experiment-order").innerHTML = "Layour Order: " + data.start_info["experiment_order_disp"];
     $('#error-exit').hide();
     $("#overcooked").empty();
     $('#game-over').hide();
@@ -140,6 +141,8 @@ socket.on('start_game', function(data) {
     $('#leave').show();
     $('#leave').attr("disabled", false)
     $('#game-title').show();
+    $('#experiment-order').show();
+    $('#experiment-order').attr("disabled", false)
     
     if (!window.spectating) {
         enable_key_listener();

--- a/src/overcooked_demo/server/static/js/index.js
+++ b/src/overcooked_demo/server/static/js/index.js
@@ -133,7 +133,7 @@ socket.on('creation_failed', function(data) {
     $('#tutorial').show();
     $('#waiting').hide();
     $('#join').show();
-    $('#join').attr("disabled", false);
+    $('#join').attr("disabled", true);
     $('#create').show();
     $('#create').attr("disabled", false);
     $('#create-next').show();
@@ -212,7 +212,7 @@ socket.on('end_game', function(data) {
     $('#game-title').hide();
     $('#game-over').show();
     $("#join").show();
-    $('#join').attr("disabled", false);
+    $('#join').attr("disabled", true);
     if (data.data && !data.data.game_flow_on) {
         $("#create").show();
         $('#create').attr("disabled", false)

--- a/src/overcooked_demo/server/static/js/index.js
+++ b/src/overcooked_demo/server/static/js/index.js
@@ -75,10 +75,10 @@ $(function() {
         var layout = document.getElementById("layout").value;
         var agentMapping = window.config_data["layout_agent_mapping"];
         try {
-            document.getElementById("playerZero").value = agentMapping[layout];
-            // document.getElementById("playerZero").text = agentMapping[layout];
+            document.getElementById("playerOne").value = agentMapping[layout];
+            // document.getElementById("playerOne").text = agentMapping[layout];
         }
-        catch(err) {document.getElementById("playerZero").value = window.config_data["layout_agent_mapping"][window.config_data["default_layout"]];console.log(err);}
+        catch(err) {document.getElementById("playerOne").value = window.config_data["layout_agent_mapping"][window.config_data["default_layout"]];console.log(err);}
     });
 });
 

--- a/src/overcooked_demo/server/static/js/index.js
+++ b/src/overcooked_demo/server/static/js/index.js
@@ -20,6 +20,30 @@ $(function() {
         $('#join').attr("disabled", true);
         $('#create').hide();
         $('#create').attr("disabled", true)
+        $('#create-next').hide();
+        $('#create-next').attr("disabled", true)
+        $("#instructions").hide();
+        $('#tutorial').hide();
+    });
+});
+
+$(function() {
+    $('#create-next').click(function () {
+        params = arrToJSON($('form').serializeArray());
+        params.layouts = [params.layout]
+        data = {
+            "params" : params,
+            "game_name" : "overcooked",
+            "create_if_not_found" : false
+        };
+        socket.emit("create-next", data);
+        $('#waiting').show();
+        $('#join').hide();
+        $('#join').attr("disabled", true);
+        $('#create').hide();
+        $('#create').attr("disabled", true)
+        $('#create-next').hide();
+        $('#create-next').attr("disabled", true)
         $("#instructions").hide();
         $('#tutorial').hide();
     });
@@ -112,6 +136,8 @@ socket.on('creation_failed', function(data) {
     $('#join').attr("disabled", false);
     $('#create').show();
     $('#create').attr("disabled", false);
+    $('#create-next').show();
+    $('#create-next').attr("disabled", false);
     $('#overcooked').append(`<h4>Sorry, game creation code failed with error: ${JSON.stringify(err)}</>`);
 });
 
@@ -187,8 +213,21 @@ socket.on('end_game', function(data) {
     $('#game-over').show();
     $("#join").show();
     $('#join').attr("disabled", false);
-    $("#create").show();
-    $('#create').attr("disabled", false)
+    if (data.data && !data.data.game_flow_on) {
+        $("#create").show();
+        $('#create').attr("disabled", false)
+    } else {
+        $("#create-next").show();
+        $('#create-next').attr("disabled", false)
+    }
+    if (data.data && data.data.is_ending) {
+        $("#create").show();
+        $('#create').attr("disabled", true)
+
+        $("#create-next").hide();
+        $('#create-next').attr("disabled", true)
+        window.alert("Please enter UID for the next player!!")
+    }
     $("#instructions").show();
     $('#tutorial').show();
     $("#leave").hide();
@@ -199,24 +238,6 @@ socket.on('end_game', function(data) {
         $('#error-exit').show();
     }
 });
-
-socket.on('end_lobby', function() {
-    // Hide lobby
-    $('#lobby').hide();
-    $("#join").show();
-    $('#join').attr("disabled", false);
-    $("#create").show();
-    $('#create').attr("disabled", false)
-    $("#leave").hide();
-    $('#leave').attr("disabled", true)
-    $("#instructions").show();
-    $('#tutorial').show();
-
-    // Stop trying to join
-    clearInterval(window.intervalID);
-    window.intervalID = -1;
-})
-
 
 /* * * * * * * * * * * * * * 
  * Game Key Event Listener *

--- a/src/overcooked_demo/server/static/js/tutorial.js
+++ b/src/overcooked_demo/server/static/js/tutorial.js
@@ -193,7 +193,7 @@ socket.on('creation_failed', function(data) {
 });
 
 socket.on('start_game', function(data) {
-    curr_tutorial_phase = 0;
+    curr_tutorial_phase = 1;
     graphics_config = {
         container_id : "overcooked",
         start_info : data.start_info
@@ -206,7 +206,7 @@ socket.on('start_game', function(data) {
     $('#show-hint').text('Show Hint');
     $('#game-title').text(`Tutorial in Progress, Phase ${curr_tutorial_phase}/${tutorial_instructions.length}`);
     $('#game-title').show();
-    $('#tutorial-instructions').append(tutorial_instructions[curr_tutorial_phase]);
+    $('#tutorial-instructions').append(tutorial_instructions[curr_tutorial_phase-1]);
     $('#instructions-wrapper').show();
     $('#hint').append(tutorial_hints[curr_tutorial_phase]);
     enable_key_listener();
@@ -220,9 +220,9 @@ socket.on('reset_game', function(data) {
     $("#overcooked").empty();
     $('#tutorial-instructions').empty();
     $('#hint').empty();
-    $("#tutorial-instructions").append(tutorial_instructions[curr_tutorial_phase]);
+    $("#tutorial-instructions").append(tutorial_instructions[curr_tutorial_phase-1]);
     $("#hint").append(tutorial_hints[curr_tutorial_phase]);
-    $('#game-title').text(`Tutorial in Progress, Phase ${curr_tutorial_phase + 1}/${tutorial_instructions.length}`);
+    $('#game-title').text(`Tutorial in Progress, Phase ${curr_tutorial_phase}/${tutorial_instructions.length}`);
     
     let button_pressed = $('#show-hint').text() === 'Hide Hint';
     if (button_pressed) {

--- a/src/overcooked_demo/server/static/templates/index.html
+++ b/src/overcooked_demo/server/static/templates/index.html
@@ -125,7 +125,7 @@
     <div id="control" class="text-center">
         <button id="create">Create Game</button>
         <button id="create-next" style="display:none">Next Game</button>
-        <button id="join">Join Existing Game</button>
+        <button id="join" disabled>Join Existing Game</button>
         <button id="leave" style="display:none;">Leave</button>
     </div>
     

--- a/src/overcooked_demo/server/static/templates/index.html
+++ b/src/overcooked_demo/server/static/templates/index.html
@@ -74,7 +74,7 @@
 	</div>
   <div class="form-group col-lg-2">
     <label for="gameTime">Game Length (sec)</label>
-    <input type="number" id="gameTime" value="80" min="1" max="1800" name="gameTime">
+    <input type="number" id="gameTime" value="10" min="1" max="1800" name="gameTime">
   </div>
   <div class="form-group col-lg-2">
     <label for="showPotential">Show Potential?</label>

--- a/src/overcooked_demo/server/static/templates/index.html
+++ b/src/overcooked_demo/server/static/templates/index.html
@@ -98,6 +98,8 @@
     <div id="waiting", class="text-center" style="display:none">
       Waiting for game to be created. Please be patient...
     </div>
+    <div id="experiment-order", class="text-center" style="display:none">
+    </div>
     <div id="overcooked-container" class="text-center">
         <h4 id="game-title" style="display:none">Game in Progress</h4>
         <h4 id="game-over" style="display:none">Game Over</h4>

--- a/src/overcooked_demo/server/static/templates/index.html
+++ b/src/overcooked_demo/server/static/templates/index.html
@@ -116,6 +116,13 @@
     </div>
     <div id="experiment-order", class="text-center" style="display:none">
     </div>
+    
+    {% if default_layout %}
+    <div id="current-layout-container" class="text-center" style="display: flex; justify-content: center; align-items: center;" >
+      <label for="current-layout">Current Layout: &nbsp;</label>
+      <p id="current-layout" style="margin: 0; position: relative; top: -2px;">{{default_layout}}</p>
+    </div>
+    {% endif %}
     <div id="overcooked-container" class="text-center">
         <h4 id="game-title" style="display:none">Game in Progress</h4>
         <h4 id="game-over" style="display:none">Game Over</h4>

--- a/src/overcooked_demo/server/static/templates/index.html
+++ b/src/overcooked_demo/server/static/templates/index.html
@@ -49,12 +49,12 @@
 	  <label for="playerZero" style="color:#1E6A9E">Player 1</label>
 	  <select class="form-control" id="playerZero" name="playerZero">
         <option value="human">Human Keyboard Input</option>
-        {% for agent_name in agent_names %}
+        <!-- {% for agent_name in agent_names %}
           <option
             value={{agent_name}}
             {% if agent_name == default_agent %} selected {% endif %}
           >{{agent_name}}</option>
-        {% endfor %}
+        {% endfor %} -->
 	  </select>
 
   </div>
@@ -65,6 +65,12 @@
         <!-- {% for agent_name in agent_names %}
             <option value={{agent_name}}>{{agent_name}}</option>
         {% endfor %} -->
+        {% for agent_name in agent_names %}
+          <option
+            value={{agent_name}}
+            {% if agent_name == default_agent %} selected {% endif %}
+          >{{agent_name}}</option>
+        {% endfor %}
     </select>
   </div>
 	<div class="form-group col-lg-2">

--- a/src/overcooked_demo/server/static/templates/index.html
+++ b/src/overcooked_demo/server/static/templates/index.html
@@ -29,13 +29,19 @@
       <div class="container">
 <!--       <h2 class="text-center">UID</h2> -->
       <!-- Form to Enter UID -->
-      <form action="/" method="POST">
+      <form action="/" method="POST" id="uid-form">
         <div class="form-group">
           <label for="uid">Enter UID:</label>
           <input type="text" id="uid" name="uid" class="form-control" required>
         </div>
         <button type="submit" class="btn btn-primary">Submit</button>
       </form>	
+      {% if uid %}
+      <div>
+        <br>
+        <label for="uid">UID :{{uid}}</label>
+      </div>
+      {% endif %}
 	<form>
       <div class="row text-center">     
 	      
@@ -74,7 +80,7 @@
 	</div>
   <div class="form-group col-lg-2">
     <label for="gameTime">Game Length (sec)</label>
-    <input type="number" id="gameTime" value="10" min="1" max="1800" name="gameTime">
+    <input type="number" id="gameTime" value="80" min="1" max="1800" name="gameTime">
   </div>
   <div class="form-group col-lg-2">
     <label for="showPotential">Show Potential?</label>
@@ -112,6 +118,7 @@
     </div>
     <div id="control" class="text-center">
         <button id="create">Create Game</button>
+        <button id="create-next" style="display:none">Next Game</button>
         <button id="join">Join Existing Game</button>
         <button id="leave" style="display:none;">Leave</button>
     </div>

--- a/src/overcooked_demo/server/tes.json
+++ b/src/overcooked_demo/server/tes.json
@@ -1,0 +1,23 @@
+{
+  "uid": "",
+  "playerZero": "PPOCoordinationRing",
+  "playerOne": "human",
+  "layout": "coordination_ring",
+  "gameTime": "10",
+  "oldDynamics": "on",
+  "dataCollection": true,
+  "xaiAgentType": "NoX",
+  "layouts": [
+    "coordination_ring",
+    "forced_coordination",
+    "cramped_room",
+    "asymmetric_advantages",
+    "counter_circuit"
+  ],
+  "mdp_params": { "old_dynamics": true },
+  "collection_config": {
+    "time": "2025-04-09_02-11-30",
+    "type": "AH",
+    "old_dynamics": "Old"
+  }
+}


### PR DESCRIPTION
-Add session round switching in to main logic, with manual button trigger. 
-Fix tutorial code to run 4 phases.
-Retain AdaX UI changes
-Prompt to add new uid for new player upon all game rounds end.

Todo: Fixes in the next commit.
- Any browser refresh causes the player_id to change. player_id is assigned the socket id (request.sid). The risk is within a player's rounds if this happened that player gets assigned a new sid/player_id. To overcome this I'll add uid collected from UI into data samples. There is some impact on this to round_id as well.
- The round_id is assigned a hash key, which seems not ideal for tracking. Therefore, round_id will be assigned the correct round id from game when saved to DB and LSL.

Minor improvements
- add logs about layout order
- integrate overcooked logs
- remove layout name from the canvas (reasons: redundant and no space)

